### PR TITLE
[43423] only retrieve active organisations and a bit of cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,8 @@ Mozilla Public License Version 2.0
 
 ### Features
 
-  - **get_cvr_no(credentials, company_name, streetname, house_no, zipcode)**
-  *Retrieves the CVR number (public unique identifier) of a given Danish company/organisation.*
-
-  - **get_org_info(credentials, cvr_no)**
-  *Retrieves name- and address information about a given company/organisation.*
+  - **get_org_info_from_org_name_and_address(credentials, company_name, streetname, house_no, zipcode)**
+  *Retrieves company/organisation information from a company name and address information.*
 
   - **get_org_info_from_cvr(credentials, cvr_no)**
   *Retrieves company/organisation information from a CVR number.*
@@ -50,9 +47,9 @@ $ cd virk.dk && python setup.py install
 ### Example of implementation
 
 ```python
-from virk_dk import get_cvr_no
+from virk_dk import get_org_info_from_org_name_and_address
 
-get_cvrnr_input_dict =	{
+input_dict =	{
   "virk_usr": "<user>",
   "virk_pwd": "<token>",
   "virk_url": "http://distribution.virk.dk/cvr-permanent/virksomhed/_search",
@@ -61,23 +58,9 @@ get_cvrnr_input_dict =	{
   "house_no_from": "43",
   "zipcode": "1112"
 }
-result = get_cvr_no(
-    params_dict=get_cvrnr_input_dict
-    )
-print(result)
-```
-```python
-from virk_dk import get_org_info
-
-get_org_input_dict =	{
-  "virk_usr": "<user>",
-  "virk_pwd": "<token>",
-  "virk_url": "http://distribution.virk.dk/cvr-permanent/virksomhed/_search",
-  "cvr": "25052943"
-}
-result = get_org_info(
-    params_dict=get_org_input_dict
-    )
+result = get_org_info_from_org_name_and_address(
+    params_dict=input_dict
+)
 print(result)
 ```
 ```python

--- a/virk_dk/__init__.py
+++ b/virk_dk/__init__.py
@@ -1,6 +1,5 @@
 from virk_dk.org_lookup import (
-    get_cvr_no,
-    get_org_info,
+    get_org_info_from_org_name_and_address,
     get_org_info_from_cvr,
     get_org_info_from_cvr_p_number_or_name,
 )

--- a/virk_dk/templates/get_org_info_from_cvr.j2
+++ b/virk_dk/templates/get_org_info_from_cvr.j2
@@ -1,7 +1,25 @@
 {
-  "query": {
-    "term": {
-      "Vrvirksomhed.cvrNummer": "{{cvr_number}}"
-    }
-  }
+   "_source":[
+      "Vrvirksomhed.cvrNummer",
+      "Vrvirksomhed.virksomhedMetadata.nyesteNavn.navn",
+      "Vrvirksomhed.virksomhedMetadata.nyesteBeliggenhedsadresse",
+      "Vrvirksomhed.virksomhedMetadata.nyesteHovedbranche",
+      "Vrvirksomhed.virksomhedMetadata.sammensatStatus",
+      "Vrvirksomhed.livsforloeb.periode.gyldigTil"
+   ],
+   "query":{
+      "bool":{
+         "must":{
+            "term":{
+               "Vrvirksomhed.cvrNummer":"{{cvr_number}}"
+            }
+         },
+         "must_not":{
+            "exists":{
+               "field":"Vrvirksomhed.livsforloeb.periode.gyldigTil"
+            }
+         }
+      }
+   },
+   "size":1
 }

--- a/virk_dk/templates/get_org_info_from_cvr_p_number_or_name.j2
+++ b/virk_dk/templates/get_org_info_from_cvr_p_number_or_name.j2
@@ -1,19 +1,31 @@
 {
-    "_source": [
-        "Vrvirksomhed.cvrNummer",
-        "Vrvirksomhed.virksomhedMetadata.nyesteNavn.navn",
-        "Vrvirksomhed.virksomhedMetadata.nyesteBeliggenhedsadresse",
-        "Vrvirksomhed.virksomhedMetadata.nyesteHovedbranche",
-        "Vrvirksomhed.virksomhedMetadata.sammensatStatus"
-    ],
-    "query": {
-        "query_string": {
-            "fields": [
-                "Vrvirksomhed.virksomhedMetadata.nyesteNavn.navn",
-                "Vrvirksomhed.virksomhedMetadata.penheder.pNummer",
-                "Vrvirksomhed.cvrNummer"
-            ],
-            "query": "(Vrvirksomhed.virksomhedMetadata.nyesteNavn.navn:{{ search_term }} OR Vrvirksomhed.penheder.pNummer:{{ search_term }} OR Vrvirksomhed.cvrNummer:{{ search_term }})"
-        }
-    }
+"_source":[
+      "Vrvirksomhed.cvrNummer",
+      "Vrvirksomhed.virksomhedMetadata.nyesteNavn.navn",
+      "Vrvirksomhed.virksomhedMetadata.nyesteBeliggenhedsadresse",
+      "Vrvirksomhed.virksomhedMetadata.nyesteHovedbranche",
+      "Vrvirksomhed.virksomhedMetadata.sammensatStatus",
+      "Vrvirksomhed.virksomhedMetadata.penheder.pNummer",
+      "Vrvirksomhed.livsforloeb.periode.gyldigTil"
+   ],
+   "query":{
+      "bool":{
+         "must":{
+            "query_string":{
+               "fields":[
+                  "Vrvirksomhed.virksomhedMetadata.nyesteNavn.navn",
+                  "Vrvirksomhed.virksomhedMetadata.penheder.pNummer",
+                  "Vrvirksomhed.cvrNummer"
+               ],
+               "query": "(Vrvirksomhed.virksomhedMetadata.nyesteNavn.navn:{{ search_term }} OR Vrvirksomhed.penheder.pNummer:{{ search_term }} OR Vrvirksomhed.cvrNummer:{{ search_term }})"
+            }
+         },
+
+         "must_not":{
+            "exists":{
+               "field":"Vrvirksomhed.livsforloeb.periode.gyldigTil"
+            }
+         }
+      }
+   }
 }

--- a/virk_dk/templates/get_org_info_from_org_name_and_address.j2
+++ b/virk_dk/templates/get_org_info_from_org_name_and_address.j2
@@ -14,9 +14,6 @@
                 "Vrvirksomhed.virksomhedMetadata.nyesteBeliggenhedsadresse.vejnavn"
             ],
             "query": "(
-                {% if cvr|length %}
-                    Vrvirksomhed.cvrNummer:{{ cvr }} 
-                {% endif %}
                 {% if navn|length %}
                     Vrvirksomhed.virksomhedMetadata.nyesteNavn.navn:{{ navn }} 
                 {% endif %}


### PR DESCRIPTION
- only filter active organisations by using "Vrvirksomhed.livsforloeb.periode.gyldigTil" as recommended by Virk https://data.virk.dk/sites/default/files/kom_godt_igang_med_elasticsearch.v6.8.10.pdf
- rename `get_cvr_no` to `get_org_info_from_org_name_and_address` and refactor it to be similar to the other functions
- remove duplicate `get_org_info` as it seems to do the same as `get_org_info_from_cvr`
- update documentation